### PR TITLE
Actualizar links de Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Contributions](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/ml-hispano/recursos-ml)[![HitCount](http://hits.dwyl.io/ml-hispano/recursos-ml.svg)](http://hits.dwyl.io/ml-hispano/recursos-ml)
 
-Listado de recursos compartidos por la comunidad **Machine Learning Hispano**. Si tu también quieres formar parte de esta comunidad, puedes unirte a través de este link : https://bit.ly/2CI89ne.
+Listado de recursos compartidos por la comunidad **Machine Learning Hispano**. Si tu también quieres formar parte de esta comunidad, puedes unirte a través de este link : https://bit.ly/2Oqingj.
 
 ### Contribución
 


### PR DESCRIPTION
El link antiguo ya no es válido.